### PR TITLE
rework icon button, redo sizing at breakpoints

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,11 +18,16 @@ const INIT = {
 const Main = styled.main`
   padding: 0 1rem 1rem;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 2fr 1fr;
   grid-gap: 1rem;
 
+  @media only screen and (max-width: ${breakpoints.lg}) {
+    grid-template-columns: 3fr 1fr;
+  }
+
   @media only screen and (max-width: ${breakpoints.md}) {
-    grid-template-columns: 1fr;
+    grid-template-columns: auto;
+    grid-template-rows: 4fr 1fr;
   }
 `;
 

--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -99,21 +99,21 @@ const ActionBar = () => {
     <Nav>
       <Left>
         <Button size="xs" outline unrounded onClick={addPC}>
-          Add Player&nbsp;
+          Player&nbsp;
           <span className="material-symbols-outlined">person</span>
         </Button>
         <Button size="xs" outline unrounded onClick={addNPC}>
-          Add NPC&nbsp;
+          NPC&nbsp;
           <span className="material-symbols-outlined">group</span>
         </Button>
         <Button size="xs" outline unrounded onClick={addMonster}>
-          Add Monster&nbsp;
+          Monster&nbsp;
           <span className="material-symbols-outlined">
             sentiment_extremely_dissatisfied
           </span>
         </Button>
         <Button size="xs" outline unrounded onClick={addHazard}>
-          Add Hazard&nbsp;
+          Hazard&nbsp;
           <span className="material-symbols-outlined">
             local_fire_department
           </span>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -10,31 +10,30 @@ const StyledButton = styled.button`
         return css`
           background-color: ${(props) =>
             props.$active
-              ? darken(0.15, colors.theme.orange)
+              ? darken(0.15, colors.white)
               : transparentize(0.75, colors.black)};
-          color: ${(props) =>
-            props.$active ? colors.white : colors.theme.orange};
-          border: solid 1px ${darken(0.15, colors.theme.orange)};
+          color: ${(props) => (props.$active ? colors.white : colors.white)};
+          border: solid 1px ${darken(0.15, colors.white)};
           &:hover:not([disabled]) {
             cursor: pointer;
             background-color: ${(props) =>
               props.$active
-                ? darken(0.1, colors.theme.orange)
+                ? darken(0.1, colors.white)
                 : transparentize(0.5, colors.black)};
           }
 
           svg {
-            fill: ${colors.theme.orange};
+            fill: ${colors.white};
           }
         `;
       default:
         return css`
-          background-color: ${darken(0.15, colors.theme.orange)};
-          border: solid 1px ${darken(0.15, colors.theme.orange)};
+          background-color: ${darken(0.15, colors.white)};
+          border: solid 1px ${darken(0.15, colors.white)};
           color: ${colors.white};
           &:hover:not([disabled]) {
             cursor: pointer;
-            background-color: ${darken(0.25, colors.theme.orange)};
+            background-color: ${darken(0.25, colors.white)};
           }
 
           svg {
@@ -90,7 +89,7 @@ const StyledButton = styled.button`
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px ${transparentize(0.5, colors.theme.orange)};
+    box-shadow: 0 0 0 3px ${transparentize(0.5, colors.white)};
   }
 `;
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,10 +8,10 @@ const StyledHeader = styled.header`
   margin: 0;
   padding: 0.5rem 1rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 2fr 1fr;
   grid-gap: 1rem;
 
-  @media only screen and (max-width: ${breakpoints.sm}) {
+  @media only screen and (max-width: ${breakpoints.md}) {
     grid-template-columns: 1fr;
   }
 `;

--- a/src/components/IconButton.jsx
+++ b/src/components/IconButton.jsx
@@ -32,7 +32,15 @@ const Button = styled.button`
   }
 `;
 
-const IconButton = ({ onClick, icon, hidden, $subtle, disabled, ...props }) => {
+const IconButton = ({
+  onClick,
+  icon,
+  hidden,
+  $subtle,
+  disabled,
+  filled,
+  ...props
+}) => {
   return (
     <Button
       onClick={onClick}
@@ -41,7 +49,14 @@ const IconButton = ({ onClick, icon, hidden, $subtle, disabled, ...props }) => {
       $subtle={$subtle}
       disabled={disabled}
     >
-      <span className="material-symbols-outlined">{icon}</span>
+      <span
+        className="material-symbols-outlined"
+        style={{
+          fontVariationSettings: filled ? "'FILL' 1" : null,
+        }}
+      >
+        {icon}
+      </span>
     </Button>
   );
 };
@@ -54,4 +69,5 @@ IconButton.propTypes = {
   hidden: PropTypes.bool,
   $subtle: PropTypes.bool,
   disabled: PropTypes.bool,
+  filled: PropTypes.bool,
 };

--- a/src/components/Initiative.jsx
+++ b/src/components/Initiative.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { breakpoints, colors } from '../utils/variables';
+import { colors } from '../utils/variables';
 import InitiativeHeader from './InitiativeHeader';
 import ActionBar from './ActionBar';
 import { useContext } from 'react';
@@ -12,12 +12,7 @@ const Div = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  height: calc(100vh - 4.75em);
   justify-content: space-between;
-
-  @media only screen and (max-width: ${breakpoints.md}) {
-    height: 71.5vh;
-  }
 `;
 
 const Assigned = styled.div`

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -8,8 +8,7 @@ const Flex = styled.div`
   display: flex;
   gap: 0.25rem;
   flex-direction: column;
-  touch-action: none;
-  -ms-touch-action: none;
+  max-height: 63dvh;
 `;
 
 const List = () => {

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -15,7 +15,7 @@ const H2 = styled.h2`
 `;
 
 const TextArea = styled.textarea`
-  height: calc(100vh - 3.7em);
+  height: calc(100dvh - 3.7em);
   line-height: 1.5;
   font-size: 2rem;
   font-family: ${fonts.body};
@@ -24,6 +24,8 @@ const TextArea = styled.textarea`
   background-color: ${transparentize(0.75, colors.white)};
   color: ${colors.pure_white};
   transition: box-shadow 0.3s;
+  width: 100%;
+  height: 100%;
 
   &:focus {
     outline: none;
@@ -31,7 +33,6 @@ const TextArea = styled.textarea`
   }
 
   @media only screen and (max-width: ${breakpoints.md}) {
-    height: 15.5vh;
     font-size: 1.5rem;
   }
 `;

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -1,10 +1,8 @@
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import { colors } from '../utils/variables';
-import _ from 'lodash';
 import { useContext } from 'react';
 import InitiativeContext from '../context/InitiativeContext';
-import { transparentize } from 'polished';
 import { keyframes } from 'styled-components';
 import IconButton from './IconButton';
 
@@ -14,9 +12,6 @@ const Flex = styled.div`
   ${(props) => {
     if (props.$dragging === props.$index) {
       return css`
-        pointer-events: none;
-        touch-action: none;
-        -ms-touch-action: none;
         background-color: ${colors.theme.gray};
       `;
     }
@@ -66,27 +61,6 @@ const Dying = styled.div`
   align-items: center;
 `;
 
-const SkullButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${(props) =>
-    _.includes(props.$status, 'dying')
-      ? colors.white
-      : transparentize(0.75, colors.white)};
-  border: none;
-  cursor: pointer;
-  border-radius: 50%;
-  width: 2.25rem;
-  height: 2.25rem;
-  background-color: ${transparentize(1, colors.black)};
-  transition: background-color 0.3s;
-
-  &:hover {
-    background-color: ${transparentize(0.5, colors.black)};
-  }
-`;
-
 const Row = ({ children, status, name, action, dragging, index }) => {
   const { initValues, setInitValues } = useContext(InitiativeContext);
   const { participants, active } = initValues;
@@ -130,13 +104,31 @@ const Row = ({ children, status, name, action, dragging, index }) => {
     });
   };
 
+  const checkFilled = (value) => {
+    let filled = false;
+    if (value === 'dying1') {
+      if (status === 'dying1' || status === 'dying2' || status === 'dying3') {
+        filled = true;
+      }
+    } else if (value === 'dying2') {
+      if (status === 'dying2' || status === 'dying3') {
+        filled = true;
+      }
+    } else if (value === 'dying3') {
+      if (status === 'dying3') {
+        filled = true;
+      }
+    }
+    return filled;
+  };
+
   const handleDying = (status) => {
     const updatedValues = participants.map((part) => {
       if (part.name === name) {
         if (part.status === status) {
           switch (part.status) {
             case 'dying1':
-              return { ...part, status: 'normal' };
+              return { ...part, status: 'alive' };
             case 'dying2':
               return { ...part, status: 'dying1' };
             case 'dying3':
@@ -195,7 +187,7 @@ const Row = ({ children, status, name, action, dragging, index }) => {
           <IconButton
             icon={'chevron_right'}
             onClick={handleDelay}
-            hidden
+            $subtle
             tabIndex={-1}
           />
         )}
@@ -205,60 +197,33 @@ const Row = ({ children, status, name, action, dragging, index }) => {
           <IconButton
             onClick={handleReady}
             icon={'keyboard_double_arrow_right'}
-            hidden
+            $subtle
             tabIndex={-1}
           />
         )}
       </Action>
       <Dying>
-        <SkullButton
+        <IconButton
+          icon="skull"
           onClick={() => handleDying('dying1')}
-          $status={status}
           tabIndex={-1}
-        >
-          <span
-            className="material-symbols-outlined"
-            style={{
-              fontVariationSettings:
-                status === 'dying1' ||
-                status === 'dying2' ||
-                status === 'dying3'
-                  ? "'FILL' 1"
-                  : null,
-            }}
-          >
-            skull
-          </span>
-        </SkullButton>
-        <SkullButton
+          filled={checkFilled('dying1')}
+          $subtle={status === 'alive'}
+        />
+        <IconButton
+          icon="skull"
           onClick={() => handleDying('dying2')}
-          $status={status}
           tabIndex={-1}
-        >
-          <span
-            className="material-symbols-outlined"
-            style={{
-              fontVariationSettings:
-                status === 'dying2' || status === 'dying3' ? "'FILL' 1" : null,
-            }}
-          >
-            skull
-          </span>
-        </SkullButton>
-        <SkullButton
+          filled={checkFilled('dying2')}
+          $subtle={status === 'alive'}
+        />
+        <IconButton
+          icon="skull"
           onClick={() => handleDying('dying3')}
-          $status={status}
           tabIndex={-1}
-        >
-          <span
-            className="material-symbols-outlined"
-            style={{
-              fontVariationSettings: status === 'dying3' ? "'FILL' 1" : null,
-            }}
-          >
-            skull
-          </span>
-        </SkullButton>
+          filled={checkFilled('dying3')}
+          $subtle={status === 'alive'}
+        />
       </Dying>
     </Flex>
   );

--- a/src/styles/Global.js
+++ b/src/styles/Global.js
@@ -5,13 +5,15 @@ export const globalCSS = css`
   body,
   html {
     margin: 0;
-    height: 100vh;
+    height: 100dvh;
     font-size: 1rem;
     background-color: ${colors.theme.gray};
   }
 
   #root {
-    height: 100vh;
+    height: 100dvh;
+    display: grid;
+    grid-template-rows: 60px 1fr;
   }
 
   *,


### PR DESCRIPTION
This PR redoes the icon button to be more flexible and allows it to replace the skull buttons. It also handles sizing of elements better for different breakpoints, hopefully fixing the issue with the url bar on mobile.