### PR TITLE
move buttons, re-add touch limitations for mobile on drag

### DIFF
--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -102,15 +102,15 @@ const ActionBar = () => {
           Player&nbsp;
           <span className="material-symbols-outlined">person</span>
         </Button>
-        <Button size="xs" outline unrounded onClick={addNPC}>
-          NPC&nbsp;
-          <span className="material-symbols-outlined">group</span>
-        </Button>
         <Button size="xs" outline unrounded onClick={addMonster}>
           Monster&nbsp;
           <span className="material-symbols-outlined">
             sentiment_extremely_dissatisfied
           </span>
+        </Button>
+        <Button size="xs" outline unrounded onClick={addNPC}>
+          NPC&nbsp;
+          <span className="material-symbols-outlined">group</span>
         </Button>
         <Button size="xs" outline unrounded onClick={addHazard}>
           Hazard&nbsp;

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -8,7 +8,7 @@ const Flex = styled.div`
   display: flex;
   gap: 0.25rem;
   flex-direction: column;
-  max-height: 63dvh;
+  max-height: 62dvh;
 `;
 
 const List = () => {
@@ -39,6 +39,9 @@ const List = () => {
     document.onpointermove = dragMove;
 
     function dragMove(e) {
+      // prevent actions on container while dragging
+      container.style.touchAction = 'none';
+
       // calculate move distance
       const posY = e.clientY - y;
 
@@ -111,6 +114,7 @@ const List = () => {
 
       setDragging(undefined);
       dragItem.style = '';
+      container.style = '';
 
       container.removeChild(div);
 

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -13,6 +13,8 @@ const Flex = styled.div`
     if (props.$dragging === props.$index) {
       return css`
         background-color: ${colors.theme.gray};
+        touch-action: none;
+        -ms-touch-action: none;
       `;
     }
   }}


### PR DESCRIPTION
This PR is meant to address the weird dragging on mobile that occurred in the last release. The touch-actions css had been removed previously, which allowed for scrolling but made the dragging funky.

With this release, the touch-actions are added to the container only during a drag, so hopefully scrolling can occur when no drag is happening.

Buttons were also moved round to account for the most likely adding scenario.